### PR TITLE
Fix broken skip domain logic

### DIFF
--- a/src/functions.go
+++ b/src/functions.go
@@ -66,7 +66,7 @@ func checkIfWeSkip(outputType uint, query string) bool {
 		}
 		return true
 	}
-	return true
+	return false
 }
 
 func loadDomainsToList(Filename string) [][]string {


### PR DESCRIPTION
Existing logic meant that queries were filtered when outputType was larger than 1 (Filtering of any kind enabled).

Fixes issue logged in issue #1 