### PR TITLE
add option to parse raw IP packets

### DIFF
--- a/src/capture_pcap.go
+++ b/src/capture_pcap.go
@@ -85,6 +85,7 @@ func newDNSCapturer(options CaptureOptions) DNSCapturer {
 		tcpReturnChannel,
 		options.ResultChannel,
 		options.Done,
+		options.NoEthernetframe,
 	}
 	var wg sync.WaitGroup
 	for i := uint(0); i < options.PacketHandlerCount; i++ {

--- a/src/detect_ip.go
+++ b/src/detect_ip.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+)
+
+// These functions implement the interface gopacket.DecodingLayer to detect
+// if a packet is either IPv4 or IPv6.
+
+func (i *DetectIP) LayerType() gopacket.LayerType {
+	return LayerTypeDetectIP
+}
+
+func (i *DetectIP) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
+	family := int(data[0] >> 4)
+	switch family {
+	case 4:
+		i.family = layers.EthernetTypeIPv4
+	case 6:
+		i.family = layers.EthernetTypeIPv6
+	default:
+		return fmt.Errorf("unknown IP family %d", family)
+	}
+	i.Payload = data
+	return nil
+}
+
+func (i *DetectIP) CanDecode() gopacket.LayerClass {
+	return LayerTypeDetectIP
+}
+
+func (i *DetectIP) NextLayerType() gopacket.LayerType {
+	return i.family.LayerType()
+}

--- a/src/main.go
+++ b/src/main.go
@@ -110,6 +110,7 @@ func main() {
 			generalOptions.DefraggerChannelSize,
 			generalOptions.DefraggerChannelReturnSize,
 			exiting,
+			captureOptions.NoEthernetframe,
 		})
 
 		// if *dnstapSocket == "" {

--- a/src/newflags.go
+++ b/src/newflags.go
@@ -20,6 +20,7 @@ var captureOptions struct {
 	AfpacketBuffersizeMb uint   `long:"afpacketBuffersizeMb" env:"DNSMONSTER_AFPACKETBUFFERSIZEMB" default:"64"                                                                                                description:"Afpacket Buffersize in MB"`
 	Filter               string `long:"filter"               env:"DNSMONSTER_FILTER"               default:"((ip and (ip[9] == 6 or ip[9] == 17)) or (ip6 and (ip6[6] == 17 or ip6[6] == 6 or ip6[6] == 44)))" description:"BPF filter applied to the packet stream. If port is selected, the packets will not be defragged."`
 	UseAfpacket          bool   `long:"useAfpacket"          env:"DNSMONSTER_USEAFPACKET"          description:"Use AFPacket for live captures. Supported on Linux 3.0+ only"`
+	NoEthernetframe      bool   `long:"noEtherframe"         env:"DNSMONSTER_NOETHERFRAME"         description:"The PCAP capture does not contain ethernet frames"`
 }
 
 var generalOptions struct {

--- a/src/packet.go
+++ b/src/packet.go
@@ -37,21 +37,30 @@ func (encoder *packetEncoder) processTransport(foundLayerTypes *[]gopacket.Layer
 }
 
 func (encoder *packetEncoder) run() {
+	var detectIP DetectIP
 	var ethLayer layers.Ethernet
 	var ip4 layers.IPv4
 	var ip6 layers.IPv6
 	var vlan layers.Dot1Q
 	var udp layers.UDP
 	var tcp layers.TCP
-	parser := gopacket.NewDecodingLayerParser(
-		layers.LayerTypeEthernet,
+
+	startLayer := layers.LayerTypeEthernet
+	decodeLayers := []gopacket.DecodingLayer{
 		&ethLayer,
 		&vlan,
 		&ip4,
 		&ip6,
 		&udp,
 		&tcp,
-	)
+	}
+	// Use the IP Family detector when no ethernet frame is present.
+	if encoder.NoEthernetframe {
+		decodeLayers[0] = &detectIP
+		startLayer = LayerTypeDetectIP
+	}
+
+	parser := gopacket.NewDecodingLayerParser(startLayer, decodeLayers...)
 	parserOnlyUDP := gopacket.NewDecodingLayerParser(
 		layers.LayerTypeUDP,
 		&udp,

--- a/src/types.go
+++ b/src/types.go
@@ -98,6 +98,7 @@ type packetEncoder struct {
 	tcpReturnChannel  <-chan tcpData
 	resultChannel     chan<- DNSResult
 	done              chan bool
+	NoEthernetframe   bool
 }
 
 // CaptureOptions is a set of generated options variables to use within our capture routine
@@ -117,6 +118,7 @@ type CaptureOptions struct {
 	IPDefraggerChannelSize       uint
 	IPDefraggerReturnChannelSize uint
 	Done                         chan bool
+	NoEthernetframe              bool
 }
 
 type ipv4ToDefrag struct {
@@ -229,4 +231,12 @@ type splunkConnection struct {
 	client    *splunk.Client
 	unhealthy uint
 	err       error
+}
+
+// Register a new Layer to detect IPv4 and IPv6 packets without an ethernet frame.
+var LayerTypeDetectIP = gopacket.RegisterLayerType(250, gopacket.LayerTypeMetadata{Name: "DetectIP", Decoder: nil})
+
+type DetectIP struct {
+	layers.BaseLayer
+	family layers.EthernetType
 }


### PR DESCRIPTION
The tool dnscap creates pcap files that do not contain any ethernet
frames but start directly with the IPv4 or IPv6 packets.

This is causing problems because the parser stops when it finds a
packet that doesn't match the starting point.

To parse these files this commit adds a new LayerType which detects if
the family is IPv4 or IPv6 and then tells the parser where to continue.

The old behaviour is kept and the new way is kept behind a switch
`--noEthernetframe`.