### PR TITLE
make use of kafka lib features

### DIFF
--- a/output/kafka.go
+++ b/output/kafka.go
@@ -21,25 +21,26 @@ type KafkaConfig struct {
 	KafkaOutputTopic  string        `long:"kafkaOutputTopic"            env:"DNSMONSTER_KAFKAOUTPUTTOPIC"            default:"dnsmonster"                                              description:"Kafka topic for logging"`
 	KafkaBatchSize    uint          `long:"kafkaBatchSize"              env:"DNSMONSTER_KAFKABATCHSIZE"              default:"1000"                                                    description:"Minimun capacity of the cache array used to send data to Kafka"`
 	KafkaBatchDelay   time.Duration `long:"kafkaBatchDelay"             env:"DNSMONSTER_KAFKABATCHDELAY"             default:"1s"                                                      description:"Interval between sending results to Kafka if Batch size is not filled"`
+	KafkaCompress     bool          `long:"kafkaCompress"               env:"DNSMONSTER_KAFKACOMPRESS"                                                                                 description:"Compress Kafka connection"`
 	outputChannel     chan types.DNSResult
 	closeChannel      chan bool
 }
 
-func (config KafkaConfig) initializeFlags() error {
+func (kafConfig KafkaConfig) initializeFlags() error {
 	// this line will run at import time, before parsing the flags, hence showing up in --help as well as actually working
-	_, err := util.GlobalParser.AddGroup("kafka_output", "Kafka Output", &config)
+	_, err := util.GlobalParser.AddGroup("kafka_output", "Kafka Output", &kafConfig)
 
-	config.outputChannel = make(chan types.DNSResult, util.GeneralFlags.ResultChannelSize)
+	kafConfig.outputChannel = make(chan types.DNSResult, util.GeneralFlags.ResultChannelSize)
 
-	types.GlobalDispatchList = append(types.GlobalDispatchList, &config)
+	types.GlobalDispatchList = append(types.GlobalDispatchList, &kafConfig)
 	return err
 }
 
 // initialize function should not block. otherwise the dispatcher will get stuck
-func (config KafkaConfig) Initialize() error {
-	if config.KafkaOutputType > 0 && config.KafkaOutputType < 5 {
+func (kafConfig KafkaConfig) Initialize() error {
+	if kafConfig.KafkaOutputType > 0 && kafConfig.KafkaOutputType < 5 {
 		log.Info("Creating Kafka Output Channel")
-		go config.Output()
+		go kafConfig.Output()
 	} else {
 		// we will catch this error in the dispatch loop and remove any output from the registry if they don't have the correct output type
 		return errors.New("no output")
@@ -47,95 +48,69 @@ func (config KafkaConfig) Initialize() error {
 	return nil
 }
 
-func (config KafkaConfig) Close() {
-	//todo: implement this
-	<-config.closeChannel
+func (kafConfig KafkaConfig) Close() {
+	close(kafConfig.closeChannel)
 }
 
-func (config KafkaConfig) OutputChannel() chan types.DNSResult {
-	return config.outputChannel
+func (kafConfig KafkaConfig) OutputChannel() chan types.DNSResult {
+	return kafConfig.outputChannel
+}
+
+func (kafConfig KafkaConfig) getWriter() *kafka.Writer {
+	kWriter := &kafka.Writer{
+		Async:        true,
+		Addr:         kafka.TCP(kafConfig.KafkaOutputBroker),
+		Topic:        kafConfig.KafkaOutputTopic,
+		Balancer:     &kafka.LeastBytes{},
+		BatchSize:    int(kafConfig.KafkaBatchSize),
+		BatchTimeout: kafConfig.KafkaBatchDelay,
+		ErrorLogger:  log.New(),
+	}
+
+	if kafConfig.KafkaCompress {
+		kWriter.Compression = kafka.Snappy
+	}
+
+	return kWriter
 }
 
 var kafkaUuidGen = fastuuid.MustNewGenerator()
 
-func (kafConfig KafkaConfig) connectKafkaRetry() *kafka.Conn {
-	tick := time.NewTicker(5 * time.Second)
-	// don't retry connection if we're doing dry run
-	if kafConfig.KafkaOutputType == 0 {
-		tick.Stop()
-	}
-	defer tick.Stop()
-	for {
-		conn, err := kafConfig.connectKafka()
-		if err == nil {
-			return conn
-		}
-
-		// Error getting connection, wait the timer or check if we are exiting
-		<-tick.C
-		continue
-
-	}
-}
-
-func (kafConfig KafkaConfig) connectKafka() (*kafka.Conn, error) {
-	conn, err := kafka.DialLeader(context.Background(), "tcp", kafConfig.KafkaOutputBroker, kafConfig.KafkaOutputTopic, 0)
-	if err != nil {
-		log.Info(err)
-		return nil, err
-	}
-
-	return conn, err
-}
-
 func (kafConfig KafkaConfig) Output() {
-	connect := kafConfig.connectKafkaRetry()
-	batch := make([]types.DNSResult, 0, kafConfig.KafkaBatchSize)
-
-	ticker := time.NewTicker(kafConfig.KafkaBatchDelay)
+	kWriter := kafConfig.getWriter()
 
 	for {
 		select {
 		case data := <-kafConfig.outputChannel:
-			if util.GeneralFlags.PacketLimit == 0 || len(batch) < util.GeneralFlags.PacketLimit {
-				batch = append(batch, data)
-			}
-		case <-ticker.C:
-			if err := kafConfig.kafkaSendData(connect, batch); err != nil {
+			if err := kafConfig.kafkaSendData(kWriter, data); err != nil {
 				log.Info(err)
-				connect = kafConfig.connectKafkaRetry()
-			} else {
-				batch = make([]types.DNSResult, 0, kafConfig.KafkaBatchSize)
 			}
-
+		case <-kafConfig.closeChannel:
+			log.Info("Closing kafka connection")
+			kWriter.Close()
+			return
 		}
 	}
 }
 
-func (kafConfig KafkaConfig) kafkaSendData(connect *kafka.Conn, batch []types.DNSResult) error {
+func (kafConfig KafkaConfig) kafkaSendData(kWriter *kafka.Writer, dnsresult types.DNSResult) error {
 	kafkaSentToOutput := metrics.GetOrRegisterCounter("kafkaSentToOutput", metrics.DefaultRegistry)
 	kafkaSkipped := metrics.GetOrRegisterCounter("stdoutSkipped", metrics.DefaultRegistry)
-	var msg []kafka.Message
-	for i := range batch {
-		for _, dnsQuery := range batch[i].DNS.Question {
-			if util.CheckIfWeSkip(kafConfig.KafkaOutputType, dnsQuery.Name) {
-				kafkaSkipped.Inc(1)
-				continue
-			}
-			kafkaSentToOutput.Inc(1)
 
-			myUUID := kafkaUuidGen.Hex128()
-
-			msg = append(msg, kafka.Message{
-				Key:   []byte(myUUID),
-				Value: []byte(fmt.Sprintf("%s\n", batch[i].String())),
-			})
-
+	for _, dnsQuery := range dnsresult.DNS.Question {
+		if util.CheckIfWeSkip(kafConfig.KafkaOutputType, dnsQuery.Name) {
+			kafkaSkipped.Inc(1)
+			return nil
 		}
 	}
-	_, err := connect.WriteMessages(msg...)
-	return err
+	kafkaSentToOutput.Inc(1)
 
+	myUUID := kafkaUuidGen.Hex128()
+
+	return kWriter.WriteMessages(context.Background(), kafka.Message{
+		Key:   []byte(myUUID),
+		Value: []byte(fmt.Sprintf("%s\n", dnsresult.String())),
+	})
 }
 
 // actually run this as a goroutine


### PR DESCRIPTION
This change makes it so we take advantage of kafka-go's features
such as:
 - ability to spread the messages across topic partitions
 - compression
 - internal batching
 - retries and reconnections
 - asynchronous

It also makes the code more simple and implements the close
functionality of the output.