### PR TITLE
dnstap improvements

### DIFF
--- a/util/types.go
+++ b/util/types.go
@@ -17,6 +17,8 @@ type DNSResult struct {
 	DstIP        net.IP
 	Protocol     string
 	PacketLength uint16
+	Identity     string
+	Version      string
 }
 
 type GenericOutput interface {


### PR DESCRIPTION
Correctly use dst ip and timestamps from response messages.
Include version and identity in messages (dnstap specific).