### PR TITLE
don't include empty fields

### DIFF
--- a/util/types.go
+++ b/util/types.go
@@ -17,8 +17,8 @@ type DNSResult struct {
 	DstIP        net.IP
 	Protocol     string
 	PacketLength uint16
-	Identity     string
-	Version      string
+	Identity     string `json:",omitempty"`
+	Version      string `json:",omitempty"`
 }
 
 type GenericOutput interface {


### PR DESCRIPTION
These fields are DNSSTAP specific, so don't include them in
the JSON field if they are empty.