### PR TITLE
store src and destination ports

### DIFF
--- a/capture/dnstap.go
+++ b/capture/dnstap.go
@@ -74,11 +74,13 @@ func dnsTapMsgToDNSResult(msg []byte) (*util.DNSResult, error) {
 	}
 
 	var myDNSResult util.DNSResult
-	myDNSResult.Identity = string(dnstapObject.Identity)
-	myDNSResult.Version = string(dnstapObject.Version)
+	myDNSResult.Identity = string(dnstapObject.GetIdentity())
+	myDNSResult.Version = string(dnstapObject.GetVersion())
 	myDNSResult.IPVersion = uint8(*dnstapObject.GetMessage().SocketFamily)*2 + 2
 	myDNSResult.SrcIP = dnstapObject.Message.GetQueryAddress()
+	myDNSResult.SrcPort = uint16(dnstapObject.Message.GetQueryPort())
 	myDNSResult.DstIP = dnstapObject.Message.GetResponseAddress()
+	myDNSResult.DstPort = uint16(dnstapObject.Message.GetResponsePort())
 	myDNSResult.Protocol = strings.ToLower(dnstapObject.Message.GetSocketProtocol().String())
 
 	message := dnstapObject.Message.GetQueryMessage()

--- a/util/types.go
+++ b/util/types.go
@@ -14,7 +14,9 @@ type DNSResult struct {
 	DNS          mkdns.Msg
 	IPVersion    uint8
 	SrcIP        net.IP
+	SrcPort      uint16 `json:",omitempty"`
 	DstIP        net.IP
+	DstPort      uint16 `json:",omitempty"`
 	Protocol     string
 	PacketLength uint16
 	Identity     string `json:",omitempty"`


### PR DESCRIPTION
Include information about which ports were used in the DNS query/response.