### PR TITLE
Initial commit of Microsoft ASIM DNS Parser

### DIFF
--- a/parser/ARM/AsimDnsDnsMonster.json
+++ b/parser/ARM/AsimDnsDnsMonster.json
@@ -1,0 +1,45 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-08-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+      "Workspace": {
+        "type": "string",
+        "metadata": {
+          "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
+        }
+      },
+      "Workspace Region": {
+        "type": "string",
+        "defaultValue": "[resourceGroup().location]",
+        "metadata": {
+          "description": "The region of the selected workspace. The default value will use the Region selection above."
+        }
+      }
+    },
+    "resources": [
+      {
+        "type": "Microsoft.OperationalInsights/workspaces",
+        "apiVersion": "2017-03-15-preview",
+        "name": "[parameters('Workspace')]",
+        "location": "[parameters('Workspace Region')]",
+        "resources": [
+          {
+            "type": "savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "ASimDnsDnsMonster",
+            "dependsOn": [
+              "[concat('Microsoft.OperationalInsights/workspaces/', parameters('Workspace'))]"
+            ],
+            "properties": {
+              "etag": "*",
+              "displayName": "DNS activity ASIM parser for DNSmonster",
+              "category": "ASIM",
+              "FunctionAlias": "ASimDnsDnsMonster",
+              "query": "let rcodes = dynamic([\"NOERROR\",\"FORMERR\",\"SERVFAIL\",\"NXDOMAIN\",\"NOTIMP\",\"REFUSED\",\"YXDOMAIN\",\"YXRRSET\",\"NXRRSET\",\"NOTAUTH\",\"NOTZONE\",\"DSOTYPENI\"]);\nlet rrcodes = dynamic([\"RESV\",\"A\",\"NS\",\"MD\",\"MF\",\"CNAME\",\"SOA\",\"MB\",\"MG\",\"MR\",\"NULL\",\"WKS\",\"PTR\",\"HINFO\",\"MINFO\",\"MX\",\"TXT\",\"RP\",\"AFSDB\",\"X25\",\"ISDN\",\"RT\",\"NSAP\",\"NSAP-PTR\",\"SIG\",\"KEY\",\"PX\",\"GPOS\",\"AAAA\",\"LOC\",\"NXT\",\"EID\",\"NIMLOC\",\"SRV\",\"ATMA\",\"NAPTR\",\"KX\",\"CERT\",\"A6\",\"DNAME\",\"SINK\",\"OPT\",\"APL\",\"DS\",\"SSHFP\",\"IPSECKEY\",\"RRSIG\",\"NSEC\",\"DNSKEY\",\"DHCID\",\"NSEC3\",\"NSEC3PARAM\",\"TLSA\",\"SMIMEA\",\"UNASSIGN\",\"HIP\",\"NINFO\",\"RKEY\",\"TALINK\",\"CDS\",\"CDNSKEY\",\"OPENPGPKEY\",\"CSYNC\",\"ZONEMD\",\"SVCB\",\"HTTPS\"]);\nlet parser=(disabled:bool=false)\n {\n   dnsmonster_CL | where not(disabled)\n   | where not(DNS_Response_b)\n   | extend DNS_Question = todynamic(DNS_Question_s)\n   | mv-expand DNS_Question\n   | extend EventType = DNS_Opcode_d,\n            EventSubType = \"request\",\n           EventResultsDetails = rcodes[toint(DNS_Rcode_d)],\n           EventSchemaVersion = \"0.1.3\",\n           EventSchema = \"Dns\",\n           Src = SrcIP_s,\n           SrcPortNumber = SrcPort_d,\n           Dst = DstIP_s,\n           DstPortNumber = DstPort_d,\n           DnsQuery = DNS_Question.Name,\n           DnsQueryType = DNS_Question.Qtype,\n           DnsQueryTypeName = rrcodes[toint(DNS_Question.Qtype)],            \n           DnsQueryClass = DNS_Question.Qclass,\n           NetworkProtocol = Protocol_s,\n           DnsFlagsAuthenticated = DNS_AuthenticatedData_b,\n           DnsFlagsAuthoritative = DNS_Authoritative_b,\n           DnsFlagsCheckingDisabled = DNS_CheckingDisabled_b,\n           DnsFlagsRecursionAvailable = DNS_RecursionAvailable_b,\n           DnsFlagsRecursionDesired = DNS_RecursionDesired_b,\n           DnsFlagsTrucated = DNS_Truncated_b\n   | project EventType,EventSubType,EventResultsDetails,EventSchemaVersion,EventSchema,Src,SrcPortNumber,Dst,DstPortNumber,\n           DnsQuery,DnsQueryType,DnsQueryTypeName,DnsQueryClass,NetworkProtocol,\n           DnsFlagsAuthenticated,DnsFlagsAuthoritative,DnsFlagsCheckingDisabled,DnsFlagsRecursionAvailable,DnsFlagsRecursionDesired,DnsFlagsTrucated\n };\n parser",
+              "version": 1
+            }
+          }
+        ]
+      }
+    ]
+  }

--- a/parser/ARM/AsimDnsDnsMonster.json
+++ b/parser/ARM/AsimDnsDnsMonster.json
@@ -1,45 +1,45 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2019-08-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-      "Workspace": {
-        "type": "string",
-        "metadata": {
-          "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
-        }
-      },
-      "Workspace Region": {
-        "type": "string",
-        "defaultValue": "[resourceGroup().location]",
-        "metadata": {
-          "description": "The region of the selected workspace. The default value will use the Region selection above."
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2019-08-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "Workspace": {
+      "type": "string",
+      "metadata": {
+        "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "resources": [
-      {
-        "type": "Microsoft.OperationalInsights/workspaces",
-        "apiVersion": "2017-03-15-preview",
-        "name": "[parameters('Workspace')]",
-        "location": "[parameters('Workspace Region')]",
-        "resources": [
-          {
-            "type": "savedSearches",
-            "apiVersion": "2020-08-01",
-            "name": "ASimDnsDnsMonster",
-            "dependsOn": [
-              "[concat('Microsoft.OperationalInsights/workspaces/', parameters('Workspace'))]"
-            ],
-            "properties": {
-              "etag": "*",
-              "displayName": "DNS activity ASIM parser for DNSmonster",
-              "category": "ASIM",
-              "FunctionAlias": "ASimDnsDnsMonster",
-              "query": "let rcodes = dynamic([\"NOERROR\",\"FORMERR\",\"SERVFAIL\",\"NXDOMAIN\",\"NOTIMP\",\"REFUSED\",\"YXDOMAIN\",\"YXRRSET\",\"NXRRSET\",\"NOTAUTH\",\"NOTZONE\",\"DSOTYPENI\"]);\nlet rrcodes = dynamic([\"RESV\",\"A\",\"NS\",\"MD\",\"MF\",\"CNAME\",\"SOA\",\"MB\",\"MG\",\"MR\",\"NULL\",\"WKS\",\"PTR\",\"HINFO\",\"MINFO\",\"MX\",\"TXT\",\"RP\",\"AFSDB\",\"X25\",\"ISDN\",\"RT\",\"NSAP\",\"NSAP-PTR\",\"SIG\",\"KEY\",\"PX\",\"GPOS\",\"AAAA\",\"LOC\",\"NXT\",\"EID\",\"NIMLOC\",\"SRV\",\"ATMA\",\"NAPTR\",\"KX\",\"CERT\",\"A6\",\"DNAME\",\"SINK\",\"OPT\",\"APL\",\"DS\",\"SSHFP\",\"IPSECKEY\",\"RRSIG\",\"NSEC\",\"DNSKEY\",\"DHCID\",\"NSEC3\",\"NSEC3PARAM\",\"TLSA\",\"SMIMEA\",\"UNASSIGN\",\"HIP\",\"NINFO\",\"RKEY\",\"TALINK\",\"CDS\",\"CDNSKEY\",\"OPENPGPKEY\",\"CSYNC\",\"ZONEMD\",\"SVCB\",\"HTTPS\"]);\nlet parser=(disabled:bool=false)\n {\n   dnsmonster_CL | where not(disabled)\n   | where not(DNS_Response_b)\n   | extend DNS_Question = todynamic(DNS_Question_s)\n   | mv-expand DNS_Question\n   | extend EventType = DNS_Opcode_d,\n            EventSubType = \"request\",\n           EventResultsDetails = rcodes[toint(DNS_Rcode_d)],\n           EventSchemaVersion = \"0.1.3\",\n           EventSchema = \"Dns\",\n           Src = SrcIP_s,\n           SrcPortNumber = SrcPort_d,\n           Dst = DstIP_s,\n           DstPortNumber = DstPort_d,\n           DnsQuery = DNS_Question.Name,\n           DnsQueryType = DNS_Question.Qtype,\n           DnsQueryTypeName = rrcodes[toint(DNS_Question.Qtype)],            \n           DnsQueryClass = DNS_Question.Qclass,\n           NetworkProtocol = Protocol_s,\n           DnsFlagsAuthenticated = DNS_AuthenticatedData_b,\n           DnsFlagsAuthoritative = DNS_Authoritative_b,\n           DnsFlagsCheckingDisabled = DNS_CheckingDisabled_b,\n           DnsFlagsRecursionAvailable = DNS_RecursionAvailable_b,\n           DnsFlagsRecursionDesired = DNS_RecursionDesired_b,\n           DnsFlagsTrucated = DNS_Truncated_b\n   | project EventType,EventSubType,EventResultsDetails,EventSchemaVersion,EventSchema,Src,SrcPortNumber,Dst,DstPortNumber,\n           DnsQuery,DnsQueryType,DnsQueryTypeName,DnsQueryClass,NetworkProtocol,\n           DnsFlagsAuthenticated,DnsFlagsAuthoritative,DnsFlagsCheckingDisabled,DnsFlagsRecursionAvailable,DnsFlagsRecursionDesired,DnsFlagsTrucated\n };\n parser",
-              "version": 1
-            }
-          }
-        ]
+    "Workspace Region": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "The region of the selected workspace. The default value will use the Region selection above."
       }
-    ]
-  }
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.OperationalInsights/workspaces",
+      "apiVersion": "2017-03-15-preview",
+      "name": "[parameters('Workspace')]",
+      "location": "[parameters('Workspace Region')]",
+      "resources": [
+        {
+          "type": "savedSearches",
+          "apiVersion": "2020-08-01",
+          "name": "ASimDnsDnsMonster",
+          "dependsOn": [
+            "[concat('Microsoft.OperationalInsights/workspaces/', parameters('Workspace'))]"
+          ],
+          "properties": {
+            "etag": "*",
+            "displayName": "DNS activity ASIM parser for DNSmonster",
+            "category": "ASIM",
+            "FunctionAlias": "ASimDnsDnsMonster",
+            "query": "let rcodes = dynamic([\"NOERROR\",\"FORMERR\",\"SERVFAIL\",\"NXDOMAIN\",\"NOTIMP\",\"REFUSED\",\"YXDOMAIN\",\"YXRRSET\",\"NXRRSET\",\"NOTAUTH\",\"NOTZONE\",\"DSOTYPENI\"]);\nlet rrcodes = dynamic([\"RESV\",\"A\",\"NS\",\"MD\",\"MF\",\"CNAME\",\"SOA\",\"MB\",\"MG\",\"MR\",\"NULL\",\"WKS\",\"PTR\",\"HINFO\",\"MINFO\",\"MX\",\"TXT\",\"RP\",\"AFSDB\",\"X25\",\"ISDN\",\"RT\",\"NSAP\",\"NSAP-PTR\",\"SIG\",\"KEY\",\"PX\",\"GPOS\",\"AAAA\",\"LOC\",\"NXT\",\"EID\",\"NIMLOC\",\"SRV\",\"ATMA\",\"NAPTR\",\"KX\",\"CERT\",\"A6\",\"DNAME\",\"SINK\",\"OPT\",\"APL\",\"DS\",\"SSHFP\",\"IPSECKEY\",\"RRSIG\",\"NSEC\",\"DNSKEY\",\"DHCID\",\"NSEC3\",\"NSEC3PARAM\",\"TLSA\",\"SMIMEA\",\"UNASSIGN\",\"HIP\",\"NINFO\",\"RKEY\",\"TALINK\",\"CDS\",\"CDNSKEY\",\"OPENPGPKEY\",\"CSYNC\",\"ZONEMD\",\"SVCB\",\"HTTPS\"]);\nlet opcodes = dynamic([\"Query\",\"IQuery\",\"Status\",\"Unassigned\",\"Notify\",\"Update\",\"DNS Stateful Operations\"]);\nlet parser=(disabled:bool=false)\n {\n   dnsmonster_CL | where not(disabled)\n   | where not(DNS_Response_b)\n   | extend DNS_Question = todynamic(DNS_Question_s)\n   | mv-expand DNS_Question\n   | extend EventType = opcodes[toint(DNS_Opcode_d)],\n            EventSubType = \"request\",\n           EventResultsDetails = rcodes[toint(DNS_Rcode_d)],\n           EventSchemaVersion = \"0.1.3\",\n           EventSchema = \"Dns\",\n           Src = SrcIP_s,\n           SrcPortNumber = SrcPort_d,\n           Dst = DstIP_s,\n           DstPortNumber = DstPort_d,\n           DnsQuery = DNS_Question.Name,\n           DnsQueryType = DNS_Question.Qtype,\n           DnsQueryTypeName = rrcodes[toint(DNS_Question.Qtype)],            \n           DnsQueryClass = DNS_Question.Qclass,\n           NetworkProtocol = Protocol_s,\n           DnsFlagsAuthenticated = DNS_AuthenticatedData_b,\n           DnsFlagsAuthoritative = DNS_Authoritative_b,\n           DnsFlagsCheckingDisabled = DNS_CheckingDisabled_b,\n           DnsFlagsRecursionAvailable = DNS_RecursionAvailable_b,\n           DnsFlagsRecursionDesired = DNS_RecursionDesired_b,\n           DnsFlagsTrucated = DNS_Truncated_b\n   | project EventType,EventSubType,EventResultsDetails,EventSchemaVersion,EventSchema,Src,SrcPortNumber,Dst,DstPortNumber,\n           DnsQuery,DnsQueryType,DnsQueryTypeName,DnsQueryClass,NetworkProtocol,\n           DnsFlagsAuthenticated,DnsFlagsAuthoritative,DnsFlagsCheckingDisabled,DnsFlagsRecursionAvailable,DnsFlagsRecursionDesired,DnsFlagsTrucated\n };\n parser",
+            "version": 1
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/parser/ARM/vimDnsDnsMonster.json
+++ b/parser/ARM/vimDnsDnsMonster.json
@@ -1,46 +1,46 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2019-08-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-      "Workspace": {
-        "type": "string",
-        "metadata": {
-          "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
-        }
-      },
-      "Workspace Region": {
-        "type": "string",
-        "defaultValue": "[resourceGroup().location]",
-        "metadata": {
-          "description": "The region of the selected workspace. The default value will use the Region selection above."
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2019-08-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "Workspace": {
+      "type": "string",
+      "metadata": {
+        "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
       }
     },
-    "resources": [
-      {
-        "type": "Microsoft.OperationalInsights/workspaces",
-        "apiVersion": "2017-03-15-preview",
-        "name": "[parameters('Workspace')]",
-        "location": "[parameters('Workspace Region')]",
-        "resources": [
-          {
-            "type": "savedSearches",
-            "apiVersion": "2020-08-01",
-            "name": "vimDnsDnsMonster",
-            "dependsOn": [
-              "[concat('Microsoft.OperationalInsights/workspaces/', parameters('Workspace'))]"
-            ],
-            "properties": {
-              "etag": "*",
-              "displayName": "DNS activity ASIM filtering parser for <product name>",
-              "category": "ASIM",
-              "FunctionAlias": "vimDnsDnsMonster",
-              "query": "let rcodes = dynamic([\"NOERROR\",\"FORMERR\",\"SERVFAIL\",\"NXDOMAIN\",\"NOTIMP\",\"REFUSED\",\"YXDOMAIN\",\"YXRRSET\",\"NXRRSET\",\"NOTAUTH\",\"NOTZONE\",\"DSOTYPENI\"]);\nlet rrcodes = dynamic([\"RESV\",\"A\",\"NS\",\"MD\",\"MF\",\"CNAME\",\"SOA\",\"MB\",\"MG\",\"MR\",\"NULL\",\"WKS\",\"PTR\",\"HINFO\",\"MINFO\",\"MX\",\"TXT\",\"RP\",\"AFSDB\",\"X25\",\"ISDN\",\"RT\",\"NSAP\",\"NSAP-PTR\",\"SIG\",\"KEY\",\"PX\",\"GPOS\",\"AAAA\",\"LOC\",\"NXT\",\"EID\",\"NIMLOC\",\"SRV\",\"ATMA\",\"NAPTR\",\"KX\",\"CERT\",\"A6\",\"DNAME\",\"SINK\",\"OPT\",\"APL\",\"DS\",\"SSHFP\",\"IPSECKEY\",\"RRSIG\",\"NSEC\",\"DNSKEY\",\"DHCID\",\"NSEC3\",\"NSEC3PARAM\",\"TLSA\",\"SMIMEA\",\"UNASSIGN\",\"HIP\",\"NINFO\",\"RKEY\",\"TALINK\",\"CDS\",\"CDNSKEY\",\"OPENPGPKEY\",\"CSYNC\",\"ZONEMD\",\"SVCB\",\"HTTPS\"]);\nlet parser=\n   (\n   starttime: datetime=datetime(null), \n   endtime: datetime=datetime(null),\n   srcipaddr: string='*',\n   domain_has_any: dynamic=dynamic([]),\n   responsecodename: string='*', \n   response_has_ipv4: string='*',\n   response_has_any_prefix: dynamic=dynamic([]),\n   eventtype: string='Query',\n   disabled:bool=false\n   ) {\n   dnsmonster_CL | where not(disabled)\n   | where not(DNS_Response_b)\n   | extend DNS_Question = todynamic(DNS_Question_s)\n   | mv-expand DNS_Question\n   | extend EventType = DNS_Opcode_d,\n       EventSubType = \"request\",\n       EventResultDetails = rcodes[toint(DNS_Opcode_d)],\n       EventSchemaVersion = \"0.1.3\",\n       EventSchema = \"Dns\",\n       Src = SrcIP_s,\n       SrcPortNumber = SrcPort_d,\n       Dst = DstIP_s,\n       DstPortNumber = DstPort_d,\n       DnsQuery = DNS_Question.Name,\n       DnsQueryType = DNS_Question.Qtype,\n       DnsQueryTypeName = rrcodes[toint(DNS_Question.Qtype)],\n       DnsQueryClass = DNS_Question.Qclass,\n       NetworkProtocol = Protocol_s,\n       DnsFlagsAuthenticated = DNS_AuthenticatedData_b,\n       DnsFlagsAuthoritative = DNS_Authoritative_b,\n       DnsFlagsCheckingDisabled = DNS_CheckingDisabled_b,\n       DnsFlagsRecursionAvailable = DNS_RecursionAvailable_b,\n       DnsFlagsRecursionDesired = DNS_RecursionDesired_b,\n       DnsFlagsTrucated = DNS_Truncated_b\n   | where (isnull(starttime) or TimeGenerated >= starttime)\n       and (isnull(endtime) or TimeGenerated <= endtime)\n       and (srcipaddr=='*' or SrcIP_s==srcipaddr)\n       and (array_length(domain_has_any) ==0 or DnsQuery has_any (domain_has_any))\n       and (responsecodename=='*' or EventResultDetails == responsecodename)\n       and (eventtype == \"*\" or eventtype == EventType or (eventtype == \"lookup\" and EventType == \"Query\"))\n   | project EventType, EventSubType, EventResultDetails, EventSchemaVersion, EventSchema, Src, SrcPortNumber, Dst, DstPortNumber,\n       DnsQuery, DnsQueryType, DnsQueryTypeName, DnsQueryClass, NetworkProtocol,\n       DnsFlagsAuthenticated, DnsFlagsAuthoritative, DnsFlagsCheckingDisabled, DnsFlagsRecursionAvailable, DnsFlagsRecursionDesired, DnsFlagsTrucated\n };\n parser (starttime, endtime, srcipaddr, domain_has_any, responsecodename, response_has_ipv4, response_has_any_prefix, eventtype, disabled)\n",
-              "version": 1,
-              "functionParameters": "starttime:datetime=datetime(null), endtime:datetime=datetime(null), srcipaddr:string='*', domain_has_any:dynamic=dynamic([]), responsecodename:string='*', response_has_ipv4:string='*', response_has_any_prefix:dynamic=dynamic([]), eventtype:string='Query'"
-            }
-          }
-        ]
+    "Workspace Region": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "The region of the selected workspace. The default value will use the Region selection above."
       }
-    ]
-  }
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.OperationalInsights/workspaces",
+      "apiVersion": "2017-03-15-preview",
+      "name": "[parameters('Workspace')]",
+      "location": "[parameters('Workspace Region')]",
+      "resources": [
+        {
+          "type": "savedSearches",
+          "apiVersion": "2020-08-01",
+          "name": "vimDnsDnsMonster",
+          "dependsOn": [
+            "[concat('Microsoft.OperationalInsights/workspaces/', parameters('Workspace'))]"
+          ],
+          "properties": {
+            "etag": "*",
+            "displayName": "DNS activity ASIM filtering parser for <product name>",
+            "category": "ASIM",
+            "FunctionAlias": "vimDnsDnsMonster",
+            "query": "let rcodes = dynamic([\"NOERROR\",\"FORMERR\",\"SERVFAIL\",\"NXDOMAIN\",\"NOTIMP\",\"REFUSED\",\"YXDOMAIN\",\"YXRRSET\",\"NXRRSET\",\"NOTAUTH\",\"NOTZONE\",\"DSOTYPENI\"]);\nlet rrcodes = dynamic([\"RESV\",\"A\",\"NS\",\"MD\",\"MF\",\"CNAME\",\"SOA\",\"MB\",\"MG\",\"MR\",\"NULL\",\"WKS\",\"PTR\",\"HINFO\",\"MINFO\",\"MX\",\"TXT\",\"RP\",\"AFSDB\",\"X25\",\"ISDN\",\"RT\",\"NSAP\",\"NSAP-PTR\",\"SIG\",\"KEY\",\"PX\",\"GPOS\",\"AAAA\",\"LOC\",\"NXT\",\"EID\",\"NIMLOC\",\"SRV\",\"ATMA\",\"NAPTR\",\"KX\",\"CERT\",\"A6\",\"DNAME\",\"SINK\",\"OPT\",\"APL\",\"DS\",\"SSHFP\",\"IPSECKEY\",\"RRSIG\",\"NSEC\",\"DNSKEY\",\"DHCID\",\"NSEC3\",\"NSEC3PARAM\",\"TLSA\",\"SMIMEA\",\"UNASSIGN\",\"HIP\",\"NINFO\",\"RKEY\",\"TALINK\",\"CDS\",\"CDNSKEY\",\"OPENPGPKEY\",\"CSYNC\",\"ZONEMD\",\"SVCB\",\"HTTPS\"]);\nlet opcodes = dynamic([\"Query\",\"IQuery\",\"Status\",\"Unassigned\",\"Notify\",\"Update\",\"DNS Stateful Operations\"]);\nlet parser=\n   (\n   starttime: datetime=datetime(null), \n   endtime: datetime=datetime(null),\n   srcipaddr: string='*',\n   domain_has_any: dynamic=dynamic([]),\n   responsecodename: string='*', \n   response_has_ipv4: string='*',\n   response_has_any_prefix: dynamic=dynamic([]),\n   eventtype: string='Query',\n   disabled:bool=false\n   ) {\n   dnsmonster_CL | where not(disabled)\n   | where not(DNS_Response_b)\n   | extend DNS_Question = todynamic(DNS_Question_s)\n   | mv-expand DNS_Question\n   | extend EventType = opcodes[toint(DNS_Opcode_d)],\n       EventSubType = \"request\",\n       EventResultDetails = rcodes[toint(DNS_Opcode_d)],\n       EventSchemaVersion = \"0.1.3\",\n       EventSchema = \"Dns\",\n       Src = SrcIP_s,\n       SrcPortNumber = SrcPort_d,\n       Dst = DstIP_s,\n       DstPortNumber = DstPort_d,\n       DnsQuery = DNS_Question.Name,\n       DnsQueryType = DNS_Question.Qtype,\n       DnsQueryTypeName = rrcodes[toint(DNS_Question.Qtype)],\n       DnsQueryClass = DNS_Question.Qclass,\n       NetworkProtocol = Protocol_s,\n       DnsFlagsAuthenticated = DNS_AuthenticatedData_b,\n       DnsFlagsAuthoritative = DNS_Authoritative_b,\n       DnsFlagsCheckingDisabled = DNS_CheckingDisabled_b,\n       DnsFlagsRecursionAvailable = DNS_RecursionAvailable_b,\n       DnsFlagsRecursionDesired = DNS_RecursionDesired_b,\n       DnsFlagsTrucated = DNS_Truncated_b\n   | where (isnull(starttime) or TimeGenerated >= starttime)\n       and (isnull(endtime) or TimeGenerated <= endtime)\n       and (srcipaddr=='*' or SrcIP_s==srcipaddr)\n       and (array_length(domain_has_any) ==0 or DnsQuery has_any (domain_has_any))\n       and (responsecodename=='*' or EventResultDetails == responsecodename)\n       and (eventtype == \"*\" or eventtype == EventType or (eventtype == \"lookup\" and EventType == \"Query\"))\n   | project EventType, EventSubType, EventResultDetails, EventSchemaVersion, EventSchema, Src, SrcPortNumber, Dst, DstPortNumber,\n       DnsQuery, DnsQueryType, DnsQueryTypeName, DnsQueryClass, NetworkProtocol,\n       DnsFlagsAuthenticated, DnsFlagsAuthoritative, DnsFlagsCheckingDisabled, DnsFlagsRecursionAvailable, DnsFlagsRecursionDesired, DnsFlagsTrucated\n };\n parser (starttime, endtime, srcipaddr, domain_has_any, responsecodename, response_has_ipv4, response_has_any_prefix, eventtype, disabled)\n",
+            "version": 1,
+            "functionParameters": "starttime:datetime=datetime(null), endtime:datetime=datetime(null), srcipaddr:string='*', domain_has_any:dynamic=dynamic([]), responsecodename:string='*', response_has_ipv4:string='*', response_has_any_prefix:dynamic=dynamic([]), eventtype:string='Query'"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/parser/ARM/vimDnsDnsMonster.json
+++ b/parser/ARM/vimDnsDnsMonster.json
@@ -1,0 +1,46 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-08-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+      "Workspace": {
+        "type": "string",
+        "metadata": {
+          "description": "The Microsoft Sentinel workspace into which the function will be deployed. Has to be in the selected Resource Group."
+        }
+      },
+      "Workspace Region": {
+        "type": "string",
+        "defaultValue": "[resourceGroup().location]",
+        "metadata": {
+          "description": "The region of the selected workspace. The default value will use the Region selection above."
+        }
+      }
+    },
+    "resources": [
+      {
+        "type": "Microsoft.OperationalInsights/workspaces",
+        "apiVersion": "2017-03-15-preview",
+        "name": "[parameters('Workspace')]",
+        "location": "[parameters('Workspace Region')]",
+        "resources": [
+          {
+            "type": "savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "vimDnsDnsMonster",
+            "dependsOn": [
+              "[concat('Microsoft.OperationalInsights/workspaces/', parameters('Workspace'))]"
+            ],
+            "properties": {
+              "etag": "*",
+              "displayName": "DNS activity ASIM filtering parser for <product name>",
+              "category": "ASIM",
+              "FunctionAlias": "vimDnsDnsMonster",
+              "query": "let rcodes = dynamic([\"NOERROR\",\"FORMERR\",\"SERVFAIL\",\"NXDOMAIN\",\"NOTIMP\",\"REFUSED\",\"YXDOMAIN\",\"YXRRSET\",\"NXRRSET\",\"NOTAUTH\",\"NOTZONE\",\"DSOTYPENI\"]);\nlet rrcodes = dynamic([\"RESV\",\"A\",\"NS\",\"MD\",\"MF\",\"CNAME\",\"SOA\",\"MB\",\"MG\",\"MR\",\"NULL\",\"WKS\",\"PTR\",\"HINFO\",\"MINFO\",\"MX\",\"TXT\",\"RP\",\"AFSDB\",\"X25\",\"ISDN\",\"RT\",\"NSAP\",\"NSAP-PTR\",\"SIG\",\"KEY\",\"PX\",\"GPOS\",\"AAAA\",\"LOC\",\"NXT\",\"EID\",\"NIMLOC\",\"SRV\",\"ATMA\",\"NAPTR\",\"KX\",\"CERT\",\"A6\",\"DNAME\",\"SINK\",\"OPT\",\"APL\",\"DS\",\"SSHFP\",\"IPSECKEY\",\"RRSIG\",\"NSEC\",\"DNSKEY\",\"DHCID\",\"NSEC3\",\"NSEC3PARAM\",\"TLSA\",\"SMIMEA\",\"UNASSIGN\",\"HIP\",\"NINFO\",\"RKEY\",\"TALINK\",\"CDS\",\"CDNSKEY\",\"OPENPGPKEY\",\"CSYNC\",\"ZONEMD\",\"SVCB\",\"HTTPS\"]);\nlet parser=\n   (\n   starttime: datetime=datetime(null), \n   endtime: datetime=datetime(null),\n   srcipaddr: string='*',\n   domain_has_any: dynamic=dynamic([]),\n   responsecodename: string='*', \n   response_has_ipv4: string='*',\n   response_has_any_prefix: dynamic=dynamic([]),\n   eventtype: string='Query',\n   disabled:bool=false\n   ) {\n   dnsmonster_CL | where not(disabled)\n   | where not(DNS_Response_b)\n   | extend DNS_Question = todynamic(DNS_Question_s)\n   | mv-expand DNS_Question\n   | extend EventType = DNS_Opcode_d,\n       EventSubType = \"request\",\n       EventResultDetails = rcodes[toint(DNS_Opcode_d)],\n       EventSchemaVersion = \"0.1.3\",\n       EventSchema = \"Dns\",\n       Src = SrcIP_s,\n       SrcPortNumber = SrcPort_d,\n       Dst = DstIP_s,\n       DstPortNumber = DstPort_d,\n       DnsQuery = DNS_Question.Name,\n       DnsQueryType = DNS_Question.Qtype,\n       DnsQueryTypeName = rrcodes[toint(DNS_Question.Qtype)],\n       DnsQueryClass = DNS_Question.Qclass,\n       NetworkProtocol = Protocol_s,\n       DnsFlagsAuthenticated = DNS_AuthenticatedData_b,\n       DnsFlagsAuthoritative = DNS_Authoritative_b,\n       DnsFlagsCheckingDisabled = DNS_CheckingDisabled_b,\n       DnsFlagsRecursionAvailable = DNS_RecursionAvailable_b,\n       DnsFlagsRecursionDesired = DNS_RecursionDesired_b,\n       DnsFlagsTrucated = DNS_Truncated_b\n   | where (isnull(starttime) or TimeGenerated >= starttime)\n       and (isnull(endtime) or TimeGenerated <= endtime)\n       and (srcipaddr=='*' or SrcIP_s==srcipaddr)\n       and (array_length(domain_has_any) ==0 or DnsQuery has_any (domain_has_any))\n       and (responsecodename=='*' or EventResultDetails == responsecodename)\n       and (eventtype == \"*\" or eventtype == EventType or (eventtype == \"lookup\" and EventType == \"Query\"))\n   | project EventType, EventSubType, EventResultDetails, EventSchemaVersion, EventSchema, Src, SrcPortNumber, Dst, DstPortNumber,\n       DnsQuery, DnsQueryType, DnsQueryTypeName, DnsQueryClass, NetworkProtocol,\n       DnsFlagsAuthenticated, DnsFlagsAuthoritative, DnsFlagsCheckingDisabled, DnsFlagsRecursionAvailable, DnsFlagsRecursionDesired, DnsFlagsTrucated\n };\n parser (starttime, endtime, srcipaddr, domain_has_any, responsecodename, response_has_ipv4, response_has_any_prefix, eventtype, disabled)\n",
+              "version": 1,
+              "functionParameters": "starttime:datetime=datetime(null), endtime:datetime=datetime(null), srcipaddr:string='*', domain_has_any:dynamic=dynamic([]), responsecodename:string='*', response_has_ipv4:string='*', response_has_any_prefix:dynamic=dynamic([]), eventtype:string='Query'"
+            }
+          }
+        ]
+      }
+    ]
+  }

--- a/parser/ASimDnsDnsMonster.yaml
+++ b/parser/ASimDnsDnsMonster.yaml
@@ -1,0 +1,51 @@
+Parser:
+  Title: DNS activity ASIM parser for DNSmonster
+  Version: '0.1'
+  LastUpdated: Mar 11 2022
+Product:
+  Name: DNSmonster
+Normalization:
+  Schema: Dns
+  Version: '0.1.3'
+References:
+- Title: ASIM DNS Schema
+  Link: https://aka.ms/ASimDnsDoc
+- Title: ASIM
+  Link: https://aka.ms/AboutASIM
+Description: |
+  This ASIM parser supports normalizing the DNSmonster logs to the ASIM DNS activity normalized schema.
+ParserName: ASimDnsDnsMonster
+ParserQuery: |
+ let rcodes = dynamic(["NOERROR","FORMERR","SERVFAIL","NXDOMAIN","NOTIMP","REFUSED","YXDOMAIN","YXRRSET","NXRRSET","NOTAUTH","NOTZONE","DSOTYPENI"]);
+ let rrcodes = dynamic(["RESV","A","NS","MD","MF","CNAME","SOA","MB","MG","MR","NULL","WKS","PTR","HINFO","MINFO","MX","TXT","RP","AFSDB","X25","ISDN","RT","NSAP","NSAP-PTR","SIG","KEY","PX","GPOS","AAAA","LOC","NXT","EID","NIMLOC","SRV","ATMA","NAPTR","KX","CERT","A6","DNAME","SINK","OPT","APL","DS","SSHFP","IPSECKEY","RRSIG","NSEC","DNSKEY","DHCID","NSEC3","NSEC3PARAM","TLSA","SMIMEA","UNASSIGN","HIP","NINFO","RKEY","TALINK","CDS","CDNSKEY","OPENPGPKEY","CSYNC","ZONEMD","SVCB","HTTPS"]);
+ let parser=(disabled:bool=false)
+  {
+    dnsmonster_CL | where not(disabled)
+    | where not(DNS_Response_b)
+    | extend DNS_Question = todynamic(DNS_Question_s)
+    | mv-expand DNS_Question
+    | extend EventType = DNS_Opcode_d,
+             EventSubType = "request",
+            EventResultsDetails = rcodes[toint(DNS_Rcode_d)],
+            EventSchemaVersion = "0.1.3",
+            EventSchema = "Dns",
+            Src = SrcIP_s,
+            SrcPortNumber = SrcPort_d,
+            Dst = DstIP_s,
+            DstPortNumber = DstPort_d,
+            DnsQuery = DNS_Question.Name,
+            DnsQueryType = DNS_Question.Qtype,
+            DnsQueryTypeName = rrcodes[toint(DNS_Question.Qtype)],            
+            DnsQueryClass = DNS_Question.Qclass,
+            NetworkProtocol = Protocol_s,
+            DnsFlagsAuthenticated = DNS_AuthenticatedData_b,
+            DnsFlagsAuthoritative = DNS_Authoritative_b,
+            DnsFlagsCheckingDisabled = DNS_CheckingDisabled_b,
+            DnsFlagsRecursionAvailable = DNS_RecursionAvailable_b,
+            DnsFlagsRecursionDesired = DNS_RecursionDesired_b,
+            DnsFlagsTrucated = DNS_Truncated_b
+    | project EventType,EventSubType,EventResultsDetails,EventSchemaVersion,EventSchema,Src,SrcPortNumber,Dst,DstPortNumber,
+            DnsQuery,DnsQueryType,DnsQueryTypeName,DnsQueryClass,NetworkProtocol,
+            DnsFlagsAuthenticated,DnsFlagsAuthoritative,DnsFlagsCheckingDisabled,DnsFlagsRecursionAvailable,DnsFlagsRecursionDesired,DnsFlagsTrucated
+  };
+  parser

--- a/parser/ASimDnsDnsMonster.yaml
+++ b/parser/ASimDnsDnsMonster.yaml
@@ -18,13 +18,14 @@ ParserName: ASimDnsDnsMonster
 ParserQuery: |
  let rcodes = dynamic(["NOERROR","FORMERR","SERVFAIL","NXDOMAIN","NOTIMP","REFUSED","YXDOMAIN","YXRRSET","NXRRSET","NOTAUTH","NOTZONE","DSOTYPENI"]);
  let rrcodes = dynamic(["RESV","A","NS","MD","MF","CNAME","SOA","MB","MG","MR","NULL","WKS","PTR","HINFO","MINFO","MX","TXT","RP","AFSDB","X25","ISDN","RT","NSAP","NSAP-PTR","SIG","KEY","PX","GPOS","AAAA","LOC","NXT","EID","NIMLOC","SRV","ATMA","NAPTR","KX","CERT","A6","DNAME","SINK","OPT","APL","DS","SSHFP","IPSECKEY","RRSIG","NSEC","DNSKEY","DHCID","NSEC3","NSEC3PARAM","TLSA","SMIMEA","UNASSIGN","HIP","NINFO","RKEY","TALINK","CDS","CDNSKEY","OPENPGPKEY","CSYNC","ZONEMD","SVCB","HTTPS"]);
+ let opcodes = dynamic(["Query","IQuery","Status","Unassigned","Notify","Update","DNS Stateful Operations"]);
  let parser=(disabled:bool=false)
   {
     dnsmonster_CL | where not(disabled)
     | where not(DNS_Response_b)
     | extend DNS_Question = todynamic(DNS_Question_s)
     | mv-expand DNS_Question
-    | extend EventType = DNS_Opcode_d,
+    | extend EventType = opcodes[toint(DNS_Opcode_d)],
              EventSubType = "request",
             EventResultsDetails = rcodes[toint(DNS_Rcode_d)],
             EventSchemaVersion = "0.1.3",

--- a/parser/README.md
+++ b/parser/README.md
@@ -1,0 +1,15 @@
+This folder contains an Azure Sentinel ASIM DNS parser for DNSmonster
+
+Feature reference: https://docs.microsoft.com/en-us/azure/sentinel/normalization-about-parsers
+Schema reference: https://docs.microsoft.com/en-us/azure/sentinel/dns-normalization-schema
+ASIM deployment: https://aka.ms/DeployASIM
+
+Usage:
+With ASIM being a preview feature, the documentation is challenging, but the basic steps are:
+- Deploy the DnsDeploymentCustomUnifyingParsers.json to your Azure tenant (https://github.com/Azure/Azure-Sentinel/tree/master/ASIM/deploy/EmptyCustomUnifyingParsers)
+- Deploy the ASimDnsDnsMoster.json template  OR
+  Create ASimDnsDnsMonster and vimDnsDnsMonster functions in your log analytics workspace and then modify the ASimDns and imDns functions as per https://docs.microsoft.com/en-us/azure/sentinel/normalization-manage-parsers#manage-workspace-deployed-unifying-parsers
+
+See also : https://docs.microsoft.com/en-us/azure/sentinel/normalization-manage-parsers
+
+Additional DNS parsers can be found here: https://github.com/Azure/Azure-Sentinel/tree/master/Parsers/ASimDns

--- a/parser/vimDnsDnsMonster.yaml
+++ b/parser/vimDnsDnsMonster.yaml
@@ -44,6 +44,7 @@ ParserParams:
 ParserQuery: |
  let rcodes = dynamic(["NOERROR","FORMERR","SERVFAIL","NXDOMAIN","NOTIMP","REFUSED","YXDOMAIN","YXRRSET","NXRRSET","NOTAUTH","NOTZONE","DSOTYPENI"]);
  let rrcodes = dynamic(["RESV","A","NS","MD","MF","CNAME","SOA","MB","MG","MR","NULL","WKS","PTR","HINFO","MINFO","MX","TXT","RP","AFSDB","X25","ISDN","RT","NSAP","NSAP-PTR","SIG","KEY","PX","GPOS","AAAA","LOC","NXT","EID","NIMLOC","SRV","ATMA","NAPTR","KX","CERT","A6","DNAME","SINK","OPT","APL","DS","SSHFP","IPSECKEY","RRSIG","NSEC","DNSKEY","DHCID","NSEC3","NSEC3PARAM","TLSA","SMIMEA","UNASSIGN","HIP","NINFO","RKEY","TALINK","CDS","CDNSKEY","OPENPGPKEY","CSYNC","ZONEMD","SVCB","HTTPS"]);
+ let opcodes = dynamic(["Query","IQuery","Status","Unassigned","Notify","Update","DNS Stateful Operations"]);
  let parser=
     (
     starttime: datetime=datetime(null), 
@@ -60,7 +61,7 @@ ParserQuery: |
     | where not(DNS_Response_b)
     | extend DNS_Question = todynamic(DNS_Question_s)
     | mv-expand DNS_Question
-    | extend EventType = DNS_Opcode_d,
+    | extend EventType = opcodes[toint(DNS_Opcode_d)],
         EventSubType = "request",
         EventResultDetails = rcodes[toint(DNS_Opcode_d)],
         EventSchemaVersion = "0.1.3",

--- a/parser/vimDnsDnsMonster.yaml
+++ b/parser/vimDnsDnsMonster.yaml
@@ -1,0 +1,93 @@
+Parser:
+  Title: DNS activity ASIM filtering parser for <product name>
+  Version: '0.1'
+  LastUpdated: Mar 11 2022
+Product:
+  Name: DNSmonster
+Normalization:
+  Schema: Dns
+  Version: '0.1.3'
+References:
+- Title: ASIM DNS Schema
+  Link: https://aka.ms/ASimDnsDoc
+- Title: ASIM
+  Link: https://aka.ms/AboutASIM
+Description: |
+  This ASIM parser supports filtering and normalizing the <product name> logs to the ASIM DNS activity normalized schema.
+ParserName: vimDnsDnsMonster
+ParserParams:
+  - Name: starttime
+    Type: datetime
+    Default: datetime(null)
+  - Name: endtime
+    Type: datetime
+    Default: datetime(null)
+  - Name: srcipaddr
+    Type: string
+    Default: '*'
+  - Name: domain_has_any
+    Type: dynamic
+    Default: dynamic([])
+  - Name: responsecodename
+    Type: string
+    Default: '*'
+  - Name: response_has_ipv4
+    Type: string
+    Default: '*'
+  - Name: response_has_any_prefix
+    Type: dynamic
+    Default: dynamic([])
+  - Name: eventtype
+    Type: string
+    Default: 'Query'
+
+ParserQuery: |
+ let rcodes = dynamic(["NOERROR","FORMERR","SERVFAIL","NXDOMAIN","NOTIMP","REFUSED","YXDOMAIN","YXRRSET","NXRRSET","NOTAUTH","NOTZONE","DSOTYPENI"]);
+ let rrcodes = dynamic(["RESV","A","NS","MD","MF","CNAME","SOA","MB","MG","MR","NULL","WKS","PTR","HINFO","MINFO","MX","TXT","RP","AFSDB","X25","ISDN","RT","NSAP","NSAP-PTR","SIG","KEY","PX","GPOS","AAAA","LOC","NXT","EID","NIMLOC","SRV","ATMA","NAPTR","KX","CERT","A6","DNAME","SINK","OPT","APL","DS","SSHFP","IPSECKEY","RRSIG","NSEC","DNSKEY","DHCID","NSEC3","NSEC3PARAM","TLSA","SMIMEA","UNASSIGN","HIP","NINFO","RKEY","TALINK","CDS","CDNSKEY","OPENPGPKEY","CSYNC","ZONEMD","SVCB","HTTPS"]);
+ let parser=
+    (
+    starttime: datetime=datetime(null), 
+    endtime: datetime=datetime(null),
+    srcipaddr: string='*',
+    domain_has_any: dynamic=dynamic([]),
+    responsecodename: string='*', 
+    response_has_ipv4: string='*',
+    response_has_any_prefix: dynamic=dynamic([]),
+    eventtype: string='Query',
+    disabled:bool=false
+    ) {
+    dnsmonster_CL | where not(disabled)
+    | where not(DNS_Response_b)
+    | extend DNS_Question = todynamic(DNS_Question_s)
+    | mv-expand DNS_Question
+    | extend EventType = DNS_Opcode_d,
+        EventSubType = "request",
+        EventResultDetails = rcodes[toint(DNS_Opcode_d)],
+        EventSchemaVersion = "0.1.3",
+        EventSchema = "Dns",
+        Src = SrcIP_s,
+        SrcPortNumber = SrcPort_d,
+        Dst = DstIP_s,
+        DstPortNumber = DstPort_d,
+        DnsQuery = DNS_Question.Name,
+        DnsQueryType = DNS_Question.Qtype,
+        DnsQueryTypeName = rrcodes[toint(DNS_Question.Qtype)],
+        DnsQueryClass = DNS_Question.Qclass,
+        NetworkProtocol = Protocol_s,
+        DnsFlagsAuthenticated = DNS_AuthenticatedData_b,
+        DnsFlagsAuthoritative = DNS_Authoritative_b,
+        DnsFlagsCheckingDisabled = DNS_CheckingDisabled_b,
+        DnsFlagsRecursionAvailable = DNS_RecursionAvailable_b,
+        DnsFlagsRecursionDesired = DNS_RecursionDesired_b,
+        DnsFlagsTrucated = DNS_Truncated_b
+    | where (isnull(starttime) or TimeGenerated >= starttime)
+        and (isnull(endtime) or TimeGenerated <= endtime)
+        and (srcipaddr=='*' or SrcIP_s==srcipaddr)
+        and (array_length(domain_has_any) ==0 or DnsQuery has_any (domain_has_any))
+        and (responsecodename=='*' or EventResultDetails == responsecodename)
+        and (eventtype == "*" or eventtype == EventType or (eventtype == "lookup" and EventType == "Query"))
+    | project EventType, EventSubType, EventResultDetails, EventSchemaVersion, EventSchema, Src, SrcPortNumber, Dst, DstPortNumber,
+        DnsQuery, DnsQueryType, DnsQueryTypeName, DnsQueryClass, NetworkProtocol,
+        DnsFlagsAuthenticated, DnsFlagsAuthoritative, DnsFlagsCheckingDisabled, DnsFlagsRecursionAvailable, DnsFlagsRecursionDesired, DnsFlagsTrucated
+  };
+  parser (starttime, endtime, srcipaddr, domain_has_any, responsecodename, response_has_ipv4, response_has_any_prefix, eventtype, disabled)


### PR DESCRIPTION
Not sure if this is something that you want to have merged into the main branch.  Seeing that you have sentinel output support, I wrote a set of ASIM DNS parsers for the logs that DNS monster imports into Microsoft Sentinel.  This allows the log entries to be used with the Microsoft normalization analytics rules in Sentinel.  More information is in the README.  I don't have a greenfield Sentinel instance to test all the installation/creation documentation against again but I believe I documented it properly.