### PR TITLE
Fix non-dnstap metrics

### DIFF
--- a/capture/nondnstap.go
+++ b/capture/nondnstap.go
@@ -47,7 +47,7 @@ func (config captureConfig) StartNonDNSTap() {
 				packetsCaptured.Update(totalCnt)
 			} else {
 				packetsCaptured.Update(int64(packets))
-				packetsCaptured.Update(int64(drop))
+				packetsDropped.Update(int64(drop))
 			}
 			packetLossPercent.Update(float64(packetsDropped.Value()) * 100.0 / float64(packetsCaptured.Value()))
 		}


### PR DESCRIPTION
### Overview
Fixes `packetsCaptured` always being overwritten for non-dnstap captures since the value of `drop` is being added to the wrong counter

### Testing
This is most apparent when we we call `Stat()` and get a value of 0 for the number of the packets dropped, causing the line
`packetLossPercent.Update(float64(packetsDropped.Value()) * 100.0 / float64(packetsCaptured.Value()))`
to cause an attempted division by 0 which results in `packetLossPercent.Value()` being equal to `NaN`. During serialization of metrics (i.e to JSON), this can prevent them from being outputted entirely if the serializer doesn't know how to interpret `NaN`. 