### PR TITLE
Prevent packetsCaptured counter from being filled with misleading values

### DIFF
--- a/capture/afpacket_linux.go
+++ b/capture/afpacket_linux.go
@@ -122,7 +122,7 @@ func (config captureConfig) initializeLiveAFpacket(devName, filter string) *afpa
 func (h *afpacketHandle) Stat() (uint, uint, error) {
 	mystats, statsv3, err := h.TPacket.SocketStats()
 	if err != nil {
-		return uint(mystats.Packets() + statsv3.Packets()), uint(mystats.Drops() + statsv3.Drops()), nil
+		return 0, 0, err
 	}
-	return 0, 0, nil
+	return uint(mystats.Packets() + statsv3.Packets()), uint(mystats.Drops() + statsv3.Drops()), nil
 }

--- a/capture/afpacket_linux.go
+++ b/capture/afpacket_linux.go
@@ -119,10 +119,10 @@ func (config captureConfig) initializeLiveAFpacket(devName, filter string) *afpa
 	return handle
 }
 
-func (h *afpacketHandle) Stat() (uint, uint) {
+func (h *afpacketHandle) Stat() (uint, uint, error) {
 	mystats, statsv3, err := h.TPacket.SocketStats()
 	if err != nil {
-		return uint(mystats.Packets() + statsv3.Packets()), uint(mystats.Drops() + statsv3.Drops())
+		return uint(mystats.Packets() + statsv3.Packets()), uint(mystats.Drops() + statsv3.Drops()), nil
 	}
-	return 0, 0
+	return 0, 0, nil
 }

--- a/capture/afpacket_nonlinux.go
+++ b/capture/afpacket_nonlinux.go
@@ -41,8 +41,8 @@ func (h *afpacketHandle) LinkType() layers.LinkType {
 func (h *afpacketHandle) Close() {
 }
 
-func (afhandle *afpacketHandle) Stat() (uint, uint) {
-	return 0, 0
+func (afhandle *afpacketHandle) Stat() (uint, uint, error) {
+	return 0, 0, nil
 }
 
 func (config captureConfig) initializeLiveAFpacket(devName, filter string) *afpacketHandle {

--- a/capture/afpacket_nonlinux.go
+++ b/capture/afpacket_nonlinux.go
@@ -42,7 +42,7 @@ func (h *afpacketHandle) Close() {
 }
 
 func (afhandle *afpacketHandle) Stat() (uint, uint, error) {
-	return 0, 0, nil
+	return 0, 0, fmt.Errorf("Afpacket statistics are only available on Linux")
 }
 
 func (config captureConfig) initializeLiveAFpacket(devName, filter string) *afpacketHandle {

--- a/capture/capture.go
+++ b/capture/capture.go
@@ -244,7 +244,7 @@ type genericPacketHandler interface {
 	ReadPacketData() ([]byte, gopacket.CaptureInfo, error)
 	ZeroCopyReadPacketData() ([]byte, gopacket.CaptureInfo, error)
 	Close()
-	Stat() (uint, uint)
+	Stat() (uint, uint, error)
 }
 
 type rawPacketBytes struct {

--- a/capture/livecap_bsd.go
+++ b/capture/livecap_bsd.go
@@ -65,13 +65,10 @@ func (h *BsdHandle) Close() {
 	h.sniffer.Close()
 }
 
-func (h *BsdHandle) Stat() (uint, uint) {
-	// in printstats, we check if this is 0, and we add the total counter to this to make sure we have a better number
-	// in essence, there should be 0 packet loss for a pcap file since the rate of the packet is controlled by i/o not network
-	// stats, err := h.handle.Stats()
-	// if err != nil {
-	// 	return uint(stats.Packets), uint(stats.Drops)
-	// }
-	//todo: find a way to do this
-	return 0, 0
+func (h *BsdHandle) Stat() (uint, uint, error) {
+	stats, err := h.handle.Stats()
+	if err != nil {
+		return uint(stats.Packets), uint(stats.Drops), nil
+	}
+	return 0, 0, err
 }

--- a/capture/livecap_bsd.go
+++ b/capture/livecap_bsd.go
@@ -68,7 +68,7 @@ func (h *BsdHandle) Close() {
 func (h *BsdHandle) Stat() (uint, uint, error) {
 	stats, err := h.handle.Stats()
 	if err != nil {
-		return uint(stats.Packets), uint(stats.Drops), nil
+		return 0, 0, err
 	}
-	return 0, 0, err
+	return uint(stats.Packets), uint(stats.Drops), nil
 }

--- a/capture/livecap_linux.go
+++ b/capture/livecap_linux.go
@@ -53,7 +53,7 @@ func (h *livePcapHandle) Close() {
 func (h *livePcapHandle) Stat() (uint, uint, error) {
 	stats, err := h.handle.Stats()
 	if err != nil {
-		return uint(stats.Packets), uint(stats.Drops), err
+		return 0, 0, err
 	}
-	return 0, 0, nil
+	return uint(stats.Packets), uint(stats.Drops), nil
 }

--- a/capture/livecap_linux.go
+++ b/capture/livecap_linux.go
@@ -50,12 +50,10 @@ func (h *livePcapHandle) Close() {
 	h.handle.Close()
 }
 
-func (h *livePcapHandle) Stat() (uint, uint) {
-	// in printstats, we check if this is 0, and we add the total counter to this to make sure we have a better number
-	// in essence, there should be 0 packet loss for a pcap file since the rate of the packet is controlled by i/o not network
+func (h *livePcapHandle) Stat() (uint, uint, error) {
 	stats, err := h.handle.Stats()
 	if err != nil {
-		return uint(stats.Packets), uint(stats.Drops)
+		return uint(stats.Packets), uint(stats.Drops), err
 	}
-	return 0, 0
+	return 0, 0, nil
 }

--- a/capture/livecap_windows.go
+++ b/capture/livecap_windows.go
@@ -38,7 +38,7 @@ func (h *livePcapHandle) Close() {
 func (h *livePcapHandle) Stat() (uint, uint, error) {
 	stats, err := h.handle.Stats()
 	if err != nil {
-		return uint(stats.PacketsReceived), uint(stats.PacketsDropped), nil
+		return 0, 0, err
 	}
-	return 0, 0, err
+	return uint(stats.PacketsReceived), uint(stats.PacketsDropped), nil
 }

--- a/capture/livecap_windows.go
+++ b/capture/livecap_windows.go
@@ -35,12 +35,10 @@ func (h *livePcapHandle) Close() {
 	h.handle.Close()
 }
 
-func (h *livePcapHandle) Stat() (uint, uint) {
-	// in printstats, we check if this is 0, and we add the total counter to this to make sure we have a better number
-	// in essence, there should be 0 packet loss for a pcap file since the rate of the packet is controlled by i/o not network
+func (h *livePcapHandle) Stat() (uint, uint, error) {
 	stats, err := h.handle.Stats()
 	if err != nil {
-		return uint(stats.PacketsReceived), uint(stats.PacketsDropped)
+		return uint(stats.PacketsReceived), uint(stats.PacketsDropped), nil
 	}
-	return 0, 0
+	return 0, 0, err
 }


### PR DESCRIPTION
### Overview
For non-dnstap handles, the implementation of `Stat` in addition to how its results are treated can be confusing and don't allow for flexibility. There is a logic constructed between the caller of `Stat` and certain handles where the return value of 0 for the number of packets captured is the same thing as 1 packet being captured. This can be evidenced by the following code, in addition to certain comments within the codebase:
```go
if packets == 0 { // to make up for pcap not being able to get stats
    packetsCaptured.Update(totalCnt)
}
```

```go
// in printstats, we check if this is 0, and we add the total counter to this to make sure we have a better number
return 0, 0
```

In my case, I am using dnsmonster with a custom handle that reads samples as perf events from an eBPF map. The `Stat` function is therefore susceptible of returning 0 when there has been nothing new outputted to the event map. When this happens, the `packetsCaptured` counter is overwritten with the total number of times that the application has tried polling for a packet.

The proposed changes do the following:
- A third return value of type `error` is added to the signature of `Stat` such that we can clearly distinguish when there has been an error. This is preferred to simply returning 0 packets captured with no additional context or an indication that there was an error, making it impossible to differentiate when a handle simply has read 0 packets because there was nothing to read versus when there was an error that prevented it from performing the read.
- Because of the aforementioned change, `packetsCaptured` can now be 0. We have to avoid the possibility of division by 0, so a guard is added around the `packetLossPercent` update call.
- For handles where the underlying implementation doesn't let you pull the stats (i.e `pcapFileHandle`), we keep track of the number by ourselves. This serves a similar purpose to  `totalCnt` in that we can still keep metrics about handles who either can't tell us how many packets were captured because of an error or those who don't provide a way of pulling the information directly from the source

### Testing
This problem was noticed as follows:
- Packet handler with `Stat` method returning `0, 0` for a continuous period of time under normal circumstances
- Exponential increase in `packetsCaptured` despite no packets being read
```
2022-09-15T16:18:59Z metrics: {"packetLossPercent":{"value":0},"packetsCaptured":{"value":5353688},"packetsDropped":{"value":0},"packetsDuplicate":{"count":0},"packetsOverRatio":{"count":0},"stdoutSentToOutput":{"count":0},"stdoutSkipped":{"count":0}}
2022-09-15T16:19:09Z metrics: {"packetLossPercent":{"value":0},"packetsCaptured":{"value":11124805},"packetsDropped":{"value":0},"packetsDuplicate":{"count":0},"packetsOverRatio":{"count":0},"stdoutSentToOutput":{"count":0},"stdoutSkipped":{"count":0}}
2022-09-15T16:19:19Z metrics: {"packetLossPercent":{"value":0},"packetsCaptured":{"value":16830117},"packetsDropped":{"value":0},"packetsDuplicate":{"count":0},"packetsOverRatio":{"count":0},"stdoutSentToOutput":{"count":0},"stdoutSkipped":{"count":0}}
```

One can observe that within the span of 10 seconds, `packetsCaptured` is continuously increasing by over 5M. If we were to print `totalCnt` on each loop iteration, we would notice that this is because the counter is being set to this value instead of remaining at 0.

While other handles were not tested (i.e livepcap), these changes should affect all of them in the same way. Furthermore, these modifications assume that, in the event of an error being thrown in `Stat`, it is preferable to output a warning message and avoid touching the `packetsCaptured` counter. 