### PR TITLE
Add RFC 9116 security.txt for dnsmonster.dev (CA-011)

### DIFF
--- a/docs/static/.well-known/security.txt
+++ b/docs/static/.well-known/security.txt
@@ -1,0 +1,6 @@
+# dnsmonster — maintained by Fenko Security (FENKO LIMITED)
+# Vulnerability reports for dnsmonster.dev and the dnsmonster project.
+Contact: mailto:security@fenko.nz
+Expires: 2027-06-12T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://dnsmonster.dev/.well-known/security.txt


### PR DESCRIPTION
Adds `/.well-known/security.txt` (RFC 9116) on the docs site, pointing vuln reports to security@fenko.nz.

Verified missing today (`https://dnsmonster.dev/.well-known/security.txt` → 404). Closes pentest remediation CA-011 for dnsmonster.dev (tracked in fenko-corp issue #33).

🤖 Generated with [Claude Code](https://claude.com/claude-code)